### PR TITLE
Basic assert lib

### DIFF
--- a/lib/assert.fs
+++ b/lib/assert.fs
@@ -1,0 +1,124 @@
+require gbhw.fs
+
+code cmovemono ( c-from c-to u -- )
+[C] ->A-> E ld,  C inc,
+[C] ->A-> D ld,  C inc,
+
+C inc, BC push,
+[C] ->A-> B ld,  C dec,
+[C] ->A-> C ld,
+
+begin, H|L->A, #NZ while,
+  [BC] ->A-> [DE] ld,
+  DE inc,
+  [BC] ->A-> [DE] ld, \ duplicate copied byte
+  BC inc,
+  DE inc,
+
+  HL dec,
+repeat,
+
+BC pop, C inc,
+ps-drop,
+end-code
+
+code disable-lcd
+[rLCDC] A ld,
+rlca,
+
+#NC ret,
+
+here<
+[rLY] A ld,
+#140 # A cp,
+<there #NZ jr,
+[rLCDC] A ld,
+A #7 # res,
+A [rLCDC] ld,
+
+ret,
+end-code
+
+[asm]
+\ label TileData
+offset constant TileData ( HACK: label is ASM-only )
+
+[host]
+also gbforth
+
+: >
+  parse-name
+  dup 8 <> if true abort" The tile line length is wrong!" then
+  0 swap
+  0 ?do
+    1 lshift
+    over i + c@ case
+      [char] X of 1 or endof
+      [char] . of      endof
+      true abort" Wrong character!"
+    endcase
+  loop
+  nip
+  rom, ;
+
+previous
+[endhost]
+
+> ........
+> ........
+> ........
+> ........
+> ........
+> ........
+> ........
+> ........
+
+> .XXXXXX.
+> XXXXXXXX
+> XX.XX.XX
+> XXXXXXXX
+> XXX..XXX
+> XX....XX
+> XXXXXXXX
+> .XXXXXX.
+
+> .XXXXXX.
+> X......X
+> X.X..X.X
+> X......X
+> X.XXXX.X
+> X..XX..X
+> X......X
+> .XXXXXX.
+
+3 constant TileCount
+
+[endasm]
+
+: copy-font
+  TileData _VRAM [ TileCount 8 * ]L cmovemono ;
+
+: enable-lcd
+  [ LCDCF_ON
+    LCDCF_BG8000 or
+    LCDCF_BG9800 or
+    LCDCF_BGON or
+    LCDCF_OBJ16 or
+    LCDCF_OBJOFF or ]L
+  rLCDC ! ;
+
+: clear-screen
+  _SCRN0 [ SCRN_VX_B SCRN_VY_B * ]L 0 fill ;
+
+#9 constant display-x
+#8 constant display-y
+
+: display-face ( f -- )
+  1 and 1 + ( false: 1, true: 2 )
+  [ _SCRN0 display-x + SCRN_VY_B display-y * + ]L
+  c! ;
+
+: assert
+  disable-lcd
+  copy-font clear-screen display-face
+  enable-lcd ;

--- a/test/gbtest.js
+++ b/test/gbtest.js
@@ -43,6 +43,10 @@ module.exports = filename => {
       }
     },
 
+    get frame() {
+      return frame;
+    },
+
     get frameSha() {
       return getSha(frame);
     },

--- a/test/test-assert.fs
+++ b/test/test-assert.fs
@@ -1,0 +1,4 @@
+require assert.fs
+
+: main
+  5 5 * 25 = assert ;

--- a/test/test-assert.js
+++ b/test/test-assert.js
@@ -1,0 +1,13 @@
+const fs = require("fs");
+const path = require("path")
+
+const gb = require("./gbtest")(__filename);
+
+test("assert", (cb) => {
+  gb.steps(200);
+  fs.writeFile(
+    path.resolve(__dirname, "test-assert.png"),
+    gb.frame,
+    cb
+  )
+});


### PR DESCRIPTION
Raw idea still, but would be nice to have a lib with tools for debugging on a real device.

This implements a super basic `assert` word that will display an icon depending on the boolean at the TOS. For example:

```forth
require assert.fs

: main
  5 5 * 25 = assert ;
```

would result in:

![assert-true](https://user-images.githubusercontent.com/1859305/41509077-d7bfd858-724e-11e8-94fc-dc91d82f8511.png)

or when false:

![assert-false](https://user-images.githubusercontent.com/1859305/41509081-e2748ac8-724e-11e8-8517-684f487a5d92.png)

