### PR TITLE
Implement simplified pictured output words

### DIFF
--- a/lib/formatted-output.fs
+++ b/lib/formatted-output.fs
@@ -33,9 +33,3 @@ variable pad-pointer
 
 : #> ( n -- )
   drop pad ;
-
-: .r ( n1 n2 -- )
-  swap <# #s #>
-  ( width addr u )
-  rot over - 0 max spaces
-  type ;

--- a/lib/memory.fs
+++ b/lib/memory.fs
@@ -1,5 +1,8 @@
 require lcd.fs
 
+: c!video
+  wait-lcd c! ;
+
 code cmovemono ( c-from c-to u -- )
   [C] ->A-> E ld,  C inc,
   [C] ->A-> D ld,  C inc,

--- a/lib/term.fs
+++ b/lib/term.fs
@@ -39,7 +39,7 @@ variable cursor-y
     0 cursor-x !
     1 cursor-y +!
   else
-    ( n ) cursor-addr c!
+    ( n ) cursor-addr c!video
     1 cursor-x +!
   then ;
 

--- a/lib/term.fs
+++ b/lib/term.fs
@@ -4,6 +4,7 @@ require ./memory.fs
 require ./input.fs
 require ./bits.fs
 require ./debug.fs
+require ./formatted-output.fs
 
 ROM
 create TileData
@@ -55,6 +56,12 @@ variable cursor-y
   postpone s"
   postpone type
 ; immediate
+
+: .r ( n1 n2 -- )
+  swap <# #s #>
+  ( width addr u )
+  rot over - 0 max spaces
+  type ;
 
 
 \ Wait until a key is pressed and return

--- a/lib/term.fs
+++ b/lib/term.fs
@@ -47,7 +47,9 @@ variable cursor-y
 : spaces 0 ?do space loop ;
 
 : type ( addr u -- )
-  cursor-addr swap cmovevideo ;
+  tuck
+  cursor-addr swap cmovevideo
+  cursor-x +! ;
 
 :m ."
   postpone s"

--- a/lib/term/formatted-output.fs
+++ b/lib/term/formatted-output.fs
@@ -6,8 +6,9 @@
 
 10 chars constant pad-size
 
-create pad-end pad-size allot
 create pad-base
+pad-size allot
+create pad-end
 
 variable pad-pointer
 

--- a/lib/term/formatted-output.fs
+++ b/lib/term/formatted-output.fs
@@ -1,0 +1,40 @@
+\ Numeric ouptut routines
+
+\ WARNING: This is just an approximation to the ANS words. It works
+\ only on base 10 and single-cell numbers for now.
+\
+
+10 chars constant pad-size
+
+create pad-end pad-size allot
+create pad-base
+
+variable pad-pointer
+
+: pad ( -- c-addr u )
+  pad-end pad-pointer @ tuck - ;
+
+: <#
+  pad-end pad-pointer ! ;
+
+: hold ( char -- )
+  -1 pad-pointer +!
+  pad-pointer @ c! ;
+
+: digit>ascii ( n -- )
+  [char] 0 + ;
+
+: # ( n1 -- n2 )
+  10 /mod swap digit>ascii hold ;
+
+: #s ( n1 -- 0 )
+  begin # dup 0= until ;
+
+: #> ( n -- )
+  drop pad ;
+
+: .r ( n1 n2 -- )
+  swap <# #s #>
+  ( width addr u )
+  rot over - 0 max spaces
+  type ;


### PR DESCRIPTION
Add words `<#` `#` `#s` `#>` and `pad`. Then, use them to implement `.R`

The idea is to remove the commented out the area of sokoban #287  that requires `.R`. However, it doesn't quite work, it seems to be writing somewhere where it shouldn't. The system hangs.

It works on GNU/Forth though, so it could be related to video memory. 

I tried replacing `c!` with a `c!video` version but still couldn't make it work so I open this PR to keep track or it for the future.