### PR TITLE
Export rom-move instead of <rom

### DIFF
--- a/examples/hello-world-asm/hello.fs
+++ b/examples/hello-world-asm/hello.fs
@@ -70,9 +70,7 @@ wait jr,
 ( HACK: Don't use gbforth internals here )
 >Title
 [host]
-also gbforth
 %title rom-move
-previous
 [target]
 
 nop,

--- a/examples/hello-world-asm/hello.fs
+++ b/examples/hello-world-asm/hello.fs
@@ -70,7 +70,7 @@ wait jr,
 ( HACK: Don't use gbforth internals here )
 >Title
 [host]
-%title rom-move
+%title rommem,
 [target]
 
 nop,

--- a/examples/hello-world-asm/hello.fs
+++ b/examples/hello-world-asm/hello.fs
@@ -1,4 +1,5 @@
 require gbhw.fs
+ROM
 
 [asm]
 
@@ -69,9 +70,7 @@ wait jr,
 
 ( HACK: Don't use gbforth internals here )
 >Title
-[host]
-%title rommem,
-[target]
+[host] %title [target] mem,
 
 nop,
 

--- a/examples/sokoban/sokoban.fs
+++ b/examples/sokoban/sokoban.fs
@@ -79,7 +79,7 @@ ROM
 
 :m m: ( "string" -- )  \ add a level line (top first!)
     [host] -1 parse [target] tuck 2dup count-$ >maze @ cell - +!
-    [host] rom-move [target]
+    [host] rommem, [target]
     /maze swap - here over bl fill allot
     >maze @ here over cell+ - swap ! ;
 

--- a/examples/sokoban/sokoban.fs
+++ b/examples/sokoban/sokoban.fs
@@ -79,7 +79,7 @@ ROM
 
 :m m: ( "string" -- )  \ add a level line (top first!)
     [host] -1 parse [target] tuck 2dup count-$ >maze @ cell - +!
-    [host] rommem, [target]
+    mem,
     /maze swap - here over bl fill allot
     >maze @ here over cell+ - swap ! ;
 

--- a/examples/sokoban/sokoban.fs
+++ b/examples/sokoban/sokoban.fs
@@ -75,16 +75,11 @@ ROM
 : count-$ ( addr u -- n )
     0 rot rot
     over + swap ?DO  I c@ [char] $ = -  LOOP ;
-
-: rom-move
-    [ also gbforth ]
-    rom-move
-    [ previous ] ;
 [target]
 
 :m m: ( "string" -- )  \ add a level line (top first!)
     [host] -1 parse [target] tuck 2dup count-$ >maze @ cell - +!
-    here [host] <rom swap move [target] dup allot
+    [host] rom-move [target]
     /maze swap - here over bl fill allot
     >maze @ here over cell+ - swap ! ;
 

--- a/src/rom.fs
+++ b/src/rom.fs
@@ -5,9 +5,9 @@ require ./utils/bytes.fs
 create rom-base rom-size allot
 variable rom-offset-variable
 
-: rom-offset rom-offset-variable @ ;
+: rom-offset rom-offset-variable @ ; \ here
 : rom-offset! rom-offset-variable ! ;
-: rom-offset+! rom-offset-variable +! ;
+: rom-offset+! rom-offset-variable +! ; \ allot
 
 : rom-buffer rom-base rom-size ;
 
@@ -54,14 +54,12 @@ rom-buffer
   rom-offset romc!
   $1 rom-offset+! ;
 
-: rom-move ( addr u -- )
-  dup >r
-  rom-offset <rom swap move
-  r> rom-offset+! ;
+: rommem, ( addr u -- )
+  rom-offset <rom over rom-offset+! swap move ; \ here over allot swap move
 
 : rom" ( -- offset u )
   rom-offset
-  [char] " parse 2dup rom-move
+  [char] " parse 2dup rommem,
   nip ;
 
 : ==> ( n -- )

--- a/src/rom.fs
+++ b/src/rom.fs
@@ -21,7 +21,7 @@ rom-buffer
 
 : assert-rom-addr ( offset -- offset )
   dup $C000 $E000 within abort" Trying to reference RAM address"
-  dup $0000 $8000 within invert abort" Trying to reference an address outside ROM" ;
+  dup $0000 rom-size within invert abort" Trying to reference an address outside ROM" ;
 
 \ Convert a ROM offset to a host address.
 \
@@ -65,6 +65,7 @@ rom-buffer
   nip ;
 
 : ==> ( n -- )
+  assert-rom-addr
   rom-offset! ;
 
 0 Value rom-fd

--- a/src/user.fs
+++ b/src/user.fs
@@ -47,7 +47,7 @@ require ./compiler/cross.fs
 get-current
 also Forth definitions
 
-export <rom
+export rom-move
 
 previous
 set-current

--- a/src/user.fs
+++ b/src/user.fs
@@ -211,6 +211,8 @@ latestxt F_IMMEDIATE create-xname ;
 : c! romc! ;
 : , assert-rom-selected rom, ;
 : c, assert-rom-selected romc, ;
+: mem, ( addr u -- )
+  assert-rom-selected rommem, ;
 : +! dup rom@ rot + swap rom! ;
 
 : fill ( offset u c -- )

--- a/src/user.fs
+++ b/src/user.fs
@@ -47,7 +47,7 @@ require ./compiler/cross.fs
 get-current
 also Forth definitions
 
-export rom-move
+export rommem,
 
 previous
 set-current


### PR DESCRIPTION
We exported `<rom` before for being a bit more reusable, but it seems like it would usually be used to do a `rom-move` (maybe a better name is possible) anyway.   