### PR TITLE
Simplify TO word

### DIFF
--- a/lib/core.fs
+++ b/lib/core.fs
@@ -556,7 +556,7 @@ end-code
 : 0= 0 = ;
 
 :m to
-  [host] 'body [target]
+  'body ( ' >body )
   postpone ! ; immediate
 
 :m is to ; immediate


### PR DESCRIPTION
Remove unneeded [host] and [target] from definition