### PR TITLE
Detect unreachable code

### DIFF
--- a/src/compiler/cross.fs
+++ b/src/compiler/cross.fs
@@ -51,9 +51,11 @@ make-ir constant unreachable-node
   to current-node ;
 
 : xreturn,
-  current-node
-  insert-node IR_NODE_RET ::type
-  to current-node ;
+  unreachable? invert if
+    current-node
+    insert-node IR_NODE_RET ::type
+    to current-node
+  then ;
 
 : process-xname ( xname -- )
   dup ximmediate? if

--- a/src/utils/errors.fs
+++ b/src/utils/errors.fs
@@ -1,0 +1,9 @@
+: .warn-line
+  ( addr u ) >r >r
+  input-error-data ( addr1 u1 addr2 u2 #line [fname-addr fname-u] )
+  cr type ." :" ( addr1 u1 addr2 u2 #line )
+  dup 0 dec.r ." : "
+  r> r> ( addr u ) type ." :" cr
+  ( #line ) if
+    ( addr1 u1 addr2 u2 ) .error-line cr
+  then ;


### PR DESCRIPTION
This detects unreachable IR nodes and shows an error when trying to compile words/literals to it:
```
test/test-ahead-then.fs:3: Unreachable code:
  ahead >>>3<<< 4 5 6 7 then
```

Similarly, the final `return,` (typically compiled by `;`) can be skipped in these definitions too.

Fixes #281