### PR TITLE
Add words to define interrupt handlers

### DIFF
--- a/examples/hello-world/hello.fs
+++ b/examples/hello-world/hello.fs
@@ -2,9 +2,19 @@ title: EXAMPLE
 
 require ibm-font.fs
 require term.fs
+require interrupt.fs
+
+variable num
+: num? 3 8 at-xy num c@ . space ;
+: num++ num c@ 1+ num c! ;
+
+p10-interrupt: num++
 
 : main
   install-font
   init-term
   3 7 at-xy
-  ." Hello World !" ;
+  ." Hello World !"
+  0 num !
+  enable-key-interrupts
+  begin num? again ;

--- a/lib/interrupt.fs
+++ b/lib/interrupt.fs
@@ -1,0 +1,53 @@
+require gbhw.fs
+
+[asm]
+:m vblank-interrupt:
+  ' rom here swap
+  $0040 ==> ( xt ) # call, reti,
+  ( here ) ==> ;
+
+:m lcd-interrupt:
+  ' rom here swap
+  $0048 ==> ( xt ) # call, reti,
+  ( here ) ==> ;
+
+:m timer-interrupt:
+  ' rom here swap
+  $0050 ==> ( xt ) # call, reti,
+  ( here ) ==> ;
+
+:m serial-interrupt:
+  ' rom here swap
+  $0058 ==> ( xt ) # call, reti,
+  ( here ) ==> ;
+
+:m p10-interrupt:
+  ' rom here swap
+  $0060 ==> ( xt ) # call, reti,
+  ( here ) ==> ;
+
+:m p11-interrupt:
+  ' rom here swap
+  $0068 ==> ( xt ) # call, reti,
+  ( here ) ==> ;
+
+:m p12-interrupt:
+  ' rom here swap
+  $0070 ==> ( xt ) # call, reti,
+  ( here ) ==> ;
+
+:m p13-interrupt:
+  ' rom here swap
+  $0078 ==> ( xt ) # call, reti,
+  ( here ) ==> ;
+[endasm]
+
+: ief! ( c -- )
+  0 rIF c!
+  rIE c@ or rIE c! ;
+
+: enable-vblank-interrupts IEF_VBLANK ief! ; \ $0040
+: enable-lcd-interrupts    IEF_LCDC   ief! ; \ $0048
+: enable-timer-interrupts  IEF_TIMER  ief! ; \ $0050
+: enable-serial-interrupts IEF_SERIAL ief! ; \ $0058
+: enable-key-interrupts    IEF_HILO   ief! ; \ $0060 $0068 $0070 $0078


### PR DESCRIPTION
Not yet working as expected. The `p10-interrupt:` does _something_, but not consistently. 