### PR TITLE
Implement SLiteral and update PARSE

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -41,24 +41,25 @@ restricted to only allocating memory there.
 
 ### Compiling strings (`s"` / `."`)
 
-In order to save space, compiled strings are stored at the dictionary pointer.
-This is usually not a problem, unless you are mixing the words `s"` or `."` with
-other words that compile data to the **DP**. For example, in standard Forth you
+The words `s"` or `."` compile strings directly to the ROM when used in a colon
+definition, but will keep the strings in the host memory when used toplevel.
+
+While this might be slightly confusing, it's consistent with the standard forth
+behaviour that strings are only available to you for a short while, and if you
+require access to them later, you need to persist them manually. For example,
 might do this to store a string:
 
 ```forth
-\ mem, copies the string to the correct location
-CREATE message s" Hello World" mem,
+\ mem, copies the string from host to ROM
+CREATE message s" Hello World!" mem,
+: main message 12 type ;
 ```
 
-But this would effectively store the same data twice, as we need to allocate the
-memory at compile time before it can be made available to the program at runtime.
-
-So in gbforth you should use:
+Or to keep things simple:
 
 ```forth
-\ already correctly placed, simply drop ( c-addr u )
-CREATE message s" Hello World" 2drop
+: message ( -- addr u ) s" Hello World!" ;
+: main message type ;
 ```
 
 ### Copying memory (`mem,`)

--- a/lib/core.fs
+++ b/lib/core.fs
@@ -591,9 +591,7 @@ end-code
 \ pretty awkward as well.
 :m s"
   [char] " parse
-  swap
-  postpone literal
-  postpone literal
+  postpone sliteral
 ; immediate
 
 :m s" [char] " parse ;

--- a/src/rom.fs
+++ b/src/rom.fs
@@ -57,11 +57,6 @@ rom-buffer
 : rommem, ( addr u -- )
   rom-offset <rom over rom-offset+! swap move ; \ here over allot swap move
 
-: romparse ( c -- offset u )
-  rom-offset swap
-  ( char ) parse 2dup rommem,
-  nip ;
-
 : ==> ( n -- )
   assert-rom-addr
   rom-offset! ;

--- a/src/user.fs
+++ b/src/user.fs
@@ -130,8 +130,7 @@ export mem>
 export >mem
 
 export char
-
-: parse romparse ;
+export parse
 
 : here xhere ;
 : unused xunused ;
@@ -229,6 +228,12 @@ include ../shared/core.fs
 : ]L xcompiling? if xliteral x] else ]L then ;
 : :noname x:noname ;
 : alias xalias ;
+
+: SLiteral ( addr u -- )
+  tuck rom-offset -rot
+  rommem,
+  postpone literal
+  postpone literal ; immediate
 
 : : x: ;
 

--- a/test/compiler/test-sliteral.fs
+++ b/test/compiler/test-sliteral.fs
@@ -1,0 +1,3 @@
+
+: main
+  [ s" hoi" ] SLiteral ;

--- a/test/compiler/test-sliteral.js
+++ b/test/compiler/test-sliteral.js
@@ -1,0 +1,11 @@
+const gb = require("../gbtest")(__filename);
+
+test("sliteral", () => {
+  gb.run();
+  expect(gb.stack.length).toEqual(2);
+  expect(gb.stack[1]).toEqual(3);
+  const addr = gb.stack[0]
+  expect(gb.memory[addr]).toEqual('h'.charCodeAt(0))
+  expect(gb.memory[addr + 1]).toEqual('o'.charCodeAt(0))
+  expect(gb.memory[addr + 2]).toEqual('i'.charCodeAt(0))
+});

--- a/test/compiler/test-two-constant.fs
+++ b/test/compiler/test-two-constant.fs
@@ -1,5 +1,5 @@
 ROM
-s" Hello" 2constant foo
+s" Hello" here -rot tuck mem, 2constant foo
 $42 $9001 2constant bar
 
 : main


### PR DESCRIPTION
**Current behaviour**
`PARSE ( -- addr u )` is defined to automatically write data into the ROM so the string is accessible at run-time. This means that words like `s"` and the derived `."` can simply compile the 2 returned cells (`addr` and `u`) into the current word definition, and strings will work as expected.

**Issues**
However, this behaviour of `s"` causes issues when using it top-level. For example when building a vector of strings like this:

```forth
CREATE vector
s" hello" mem,
s" world" mem,

: main
  vector     5 type   \ expect hello
  vector 5 + 5 type ; \ expect world
```

This code works in gforth, but gbforth duplicates the strings and starts appending them to the dictionary pointer which is unintended.

**Solution**
Instead of having `PARSE` automatically move strings to the ROM, it should keep them in HOST memory until explicitly moved to the rom. In top-level code this can be done manually with a word like `mem,` (already implemented). The words `s"` and  `."` can be redefined to use `SLiteral` (not yet implemented) which compiles the string to the dictionary pointer, if used in a (target) colon definition. That means that this code still works correctly as before:

```forth
: main
  ." hello"
  s" world" type ;
```

But this will not:

```forth
s" hello" 2constant greet \ this contains a HOST address
: main
  greet type ; 
```

While mixing host/rom addresses can be confusing, the behaviour is consistent with gforth where strings are stored into transient memory, and need to be explicitly stored for later use.

---

**tl;dr**
- Changes in behaviour of `parse`, and the top-level version of `s"`: Both return a host address now instead of compiling strings into the target ROM.
- The colon versions of `."` and `s"` now use `SLiteral` to copy the string from host to ROM, instead of this being done by `parse`, but achieve the same behaviour as before.

Closes #70 