### PR TITLE
Strings lib

### DIFF
--- a/lib/long-strings.fs
+++ b/lib/long-strings.fs
@@ -1,0 +1,29 @@
+require ./formatted-output.fs
+
+\ override place, count and +place
+\ with a cell-counted version that
+\ allows for 255+ character strings
+
+: place ( c-addr1 u1 c-addr2 -- )
+  over >r rot over cell+ r> move ! ;
+
+: count ( c-addr1 -- c-addr2 u )
+  dup cell+ swap @ ;
+
+: +place ( c-addr1 u1 c-addr2 -- )
+  over over >r >r
+  count chars +
+  swap chars move
+  r> r@ @ + r> ! ;
+
+\ override additional words from strings lib
+\ to work with redefined place and +place
+
+: c+place ( c c-addr )
+  dup @ char+ over !
+  count 1- chars + ! ;
+
+: #+place ( u c-addr -- )
+  swap
+  dup abs <# #s swap sign #>
+  rot +place ;

--- a/lib/long-strings.fs
+++ b/lib/long-strings.fs
@@ -27,3 +27,22 @@ require ./formatted-output.fs
   swap
   dup abs <# #s swap sign #>
   rot +place ;
+
+\ define an additional word wrap. to display
+\ long text wrapped within the screen. returns
+\ the remaining addr' u' portion if the text
+\ does not fit on one page, or 0 0 if all text
+\ was written to the screen
+
+: wrap. ( addr u -- addr' u' )
+  begin
+    dup SCRN_X_B >
+  while
+    over SCRN_X_B
+    begin 1- 2dup + c@ bl = until
+    dup 1+ >r
+    begin 1- 2dup + c@ bl <> until
+    1+ type cr
+    r> /string
+    cursor-y @ SCRN_Y_B = if exit then
+  repeat type cr 0 0 ;

--- a/lib/strings.fs
+++ b/lib/strings.fs
@@ -1,0 +1,15 @@
+require ./formatted-output.fs
+
+: toupper ( c -- c )
+  dup
+  [ char a ]L [ char z 1+ ]L within
+  if 32 - then ;
+
+: c+place ( c c-addr -- )
+  dup c@ char+ over c!
+  count 1- chars + c! ;
+
+: #+place ( u c-addr -- )
+  swap
+  dup abs <# #s swap sign #>
+  rot +place ;

--- a/test/libs/test-strings.fs
+++ b/test/libs/test-strings.fs
@@ -1,0 +1,11 @@
+require strings.fs
+
+create note 100 chars allot
+
+: main
+  s" Forth "       note   place
+  4                note #+place
+  s"  the "        note  +place
+  [char] g toupper note c+place
+  [char] B toupper note c+place
+  note ;

--- a/test/libs/test-strings.js
+++ b/test/libs/test-strings.js
@@ -1,0 +1,13 @@
+const gb = require("../gbtest")(__filename);
+
+const readCountedString = (addr) => {
+  const len = gb.memory[addr]
+  const chars = gb.memory.slice(addr + 1, addr + 1 + len)
+  return String.fromCharCode(...chars)
+}
+
+test("strings-ext", () => {
+  gb.run();
+  expect(gb.stack.length).toBe(1);
+  expect(readCountedString(gb.stack[0])).toBe("Forth 4 the GB")
+});


### PR DESCRIPTION
Some extra words for working with strings.

**Appending strings**
`+PLACE` (sometimes known as `append`) is already added to the core lib, as it's a very common (even if non-standard) word.

**Appending characters or numbers**
This strings lib adds `c+place` and `#+place` for appending a single character or numeric value to a string. Not sure about existing name conventions? This used to be `cappend` and `#append`, but being consistent with `+place` probably makes sense.

**Longer counted strings**
gbforth supports counted strings (and the related words `place` and `count`) that use a single char for storing the string length. This limits the length of counted strings to 255 characters.

Some forth systems use a cell (2 chars) for this, so longer strings are allowed, at the expense of using a bit more bytes for storage. While using strings that are longer than 255 characters might not be very common, it might be nice to support them anyway so that things ✨ just work ✨  

Alternatively, we can include a `longer-strings.fs` lib that redefines the words `place` and `+place` (and any other related words) to use a cell count rather than a char count.

**Todo**
- [ ] Name for `char +place` and `num +place` words
- [ ] Consider using a CELL instead of CHAR for counted strings?